### PR TITLE
Enable "chunked compression" of DataArrays in VTU files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+Overview
+=====
+
+A repo containing tools for writing mesh files in various formats.
+
+Note: this library is expected to change rapidly, so do not expect any form of API stability.
+
+Requirements
+========
+
+- A C++17 compatible compiler
+
+Building the library and its dependencies
+=================
+
+1. Clone the repo:
+
+`git clone https://github.com/samuelpmish/mesh_stuff.git`
+
+---------
+
+2. Configure with `cmake`
+
+with no OpenGL stuff enabled
+
+`cd path/to/mesh_stuff && cmake . -Bbuild`
+
+---------
+
+3. build
+
+`cd build && make`

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Building the library and its dependencies
 
 2. Configure with `cmake`
 
-with no OpenGL stuff enabled
-
 `cd path/to/mesh_stuff && cmake . -Bbuild`
 
 ---------

--- a/tests/vtu_export_tests.cpp
+++ b/tests/vtu_export_tests.cpp
@@ -33,3 +33,37 @@ TEST(vtu, export_tests) {
     // 14-node pyramids seem to not be supported by vtu (?)
     // export_vtu_single_element(Element::Type::Pyr14, "pyr14");
 }
+
+inline std::vector<int> range(int i, int j) {
+    std::vector<int> values;
+    for (; i < j; ++i) { values.push_back(i); }
+    return values;
+}
+
+// Create a mesh large enough that more than one 4MB block is compressed. For simplicity, elements have no connectivity
+// with other elements, so connectivity data and node location data have equal size for default int32 and float types.
+TEST(vtu, multi_block_compression) {
+
+    struct TestCase {
+        Element::Type type;
+        int num_elements; // choose such that connectivity and node location data are > 4MB
+        std::string name;
+    };
+    std::vector<TestCase> TEST_SET { {Element::Type::Tet4, 275000, "tet4_multiblock"},
+                                     {Element::Type::Tet10, 125000, "tet10_multiblock"} };
+
+    for (const TestCase &tc : TEST_SET) {
+
+        const int n = nodes_per_elem(tc.type);
+        std::vector<vec3> node_locations(n * tc.num_elements);
+        std::vector<Element> element_definitions(tc.num_elements);
+
+        for (int i = 0; i < tc.num_elements; ++i) {
+            for (int j = 0; j < n; ++j) {
+                node_locations[n*i+j] = tetrahedron_nodes[j]; // NOTE hard-coding to only tet elements
+            }
+            element_definitions[i] = Element{tc.type, range(n*i, n*(i+1))};
+        }
+        export_vtu(Mesh{node_locations, element_definitions}, tc.name+".vtu");
+    }
+}


### PR DESCRIPTION
This PR factors the DataArray compression for VTU files into a common function, and generalizes the data header we write from a single chuck that contains all the data to now handle chunks of a client-selectable size. However, note that at the moment the client-facing method (as opposed to the implementation method) hard-codes a default 4 MB size.

This PR does not implement any threading for the chunk compressions.

I tested this PR by running the VTU test, then running the tet4.vtu file through an MFEM driver to confirm it reads the compressed data correctly.